### PR TITLE
PrimArray Monomorphization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+*.swp
 dist-newstyle/
+cabal.project.local

--- a/array-statistics.cabal
+++ b/array-statistics.cabal
@@ -23,6 +23,7 @@ library
     , base >=4.11.1
     , contiguous >=0.6.1
     , primitive-sort
+    , primitive >=0.7.1
   default-language: Haskell2010
   ghc-options: -O2 -Wall -Wunticked-promoted-constructors
 
@@ -49,7 +50,8 @@ benchmark bench
     , array-statistics
     , base
     , contiguous
-    , gauge
+    , gauge >=0.2.5
     , random >=1.2
+    , primitive
   default-language: Haskell2010
   ghc-options: -Wall -O2

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -2,34 +2,48 @@
 
 import Gauge.Main (defaultMain, bench, whnf)
 
+import Data.Int (Int64)
 import Data.List (unfoldr)
 import Data.Maybe (fromJust)
 import Data.Primitive.Contiguous (PrimArray, fromListN)
 import Statistics.Array.Types (AscList)
 import System.Random (random, mkStdGen)
 
+import qualified Data.Primitive as PM
 import qualified Statistics.Array as Stats
 import qualified Statistics.Array.Types as Asc
 
 main :: IO ()
 main = defaultMain
-  [ bench "sort-16" $ whnf (fromJust . Asc.fromArray) input16
-  , bench "sort-128" $ whnf (fromJust . Asc.fromArray) input128
-  , bench "sort-1024" $ whnf (fromJust . Asc.fromArray) input1024
-  , bench "sort-65536" $ whnf (fromJust . Asc.fromArray) input65536
-  , bench "list-derivative" $ whnf Stats.listDerivative asc1024
+  [ bench "sort-16" $ whnf fromAscInt input16
+  , bench "sort-128" $ whnf fromAscInt input128
+  , bench "sort-1024" $ whnf fromAscInt input1024
+  , bench "sort-65536" $ whnf fromAscInt input65536
+  , bench "list-derivative" $ whnf performListDerivativeInt asc1024
   , bench "median-of-absolute-deviations" $ whnf Stats.mad asc1024
   ]
   where
-  input16, input128, input1024, input65536 :: PrimArray Int
+  input16, input128, input1024, input65536 :: PrimArray Int64
   !input16 = fromListN 16 $ take 16 . drop 0 $ inputInf
   !input128 = fromListN 128 $ take 128 . drop 16 $ inputInf
   !input1024 = fromListN 1024 $ take 1024 . drop (16+128) $ inputInf
   !input65536 = fromListN 65536 $ take 65536 . drop (16+128+1024) $ inputInf
-  asc1024 :: AscList PrimArray Int
+  asc1024 :: AscList Int64
   asc1024 = fromJust $ Asc.fromArray input1024
 
-inputInf :: [Int]
+fromAscInt :: PrimArray Int64 -> Int64
+{-# noinline fromAscInt #-}
+fromAscInt !x = case Asc.fromArray x of
+  Nothing -> 0
+  Just (Asc.AscList y) -> fromIntegral (PM.sizeofPrimArray y)
+
+-- This is here to make it easy to inspect Core to confirm that specialization
+-- works correctly. 
+performListDerivativeInt :: AscList Int64 -> PrimArray Int64
+{-# noinline performListDerivativeInt #-}
+performListDerivativeInt !x = Stats.listDerivative x
+
+inputInf :: [Int64]
 inputInf = unfoldr (Just . random) seed
   where
   seed = mkStdGen 1234567

--- a/cabal.project
+++ b/cabal.project
@@ -5,4 +5,4 @@ with-compiler: ghc-8.10.4
 source-repository-package
   type: git
   location: https://github.com/andrewthad/primitive-sort
-  tag: b8426c7a0a74e246b7cdd250ead1ec4d8aace30a
+  tag: a724d3cd015e23b3ff92f29383b999fad0921586

--- a/src/Statistics/Array.hs
+++ b/src/Statistics/Array.hs
@@ -5,11 +5,15 @@
 
 module Statistics.Array
   ( median
+  , minimum
+  , maximum
   , quartiles
   , listDerivative
   , mad
   , bowleySkew
   ) where
+
+import Prelude hiding (minimum,maximum)
 
 import Control.Monad (forM_)
 import Data.Int (Int64)
@@ -21,6 +25,7 @@ import qualified Data.Primitive.Contiguous as Arr
 import qualified Data.Primitive.Sort as Arr
 import qualified Statistics.Array.Types as Asc
 
+-- | @O(1)@ Median element.
 median :: Prim a
   => AscList a -> a
 {-# inlineable median #-}
@@ -28,6 +33,24 @@ median :: Prim a
 {-# specialize median :: AscList Int64 -> Int64 #-}
 {-# specialize median :: AscList Double -> Double #-}
 median (AscList arr) = Arr.index arr (Arr.size arr `div` 2)
+
+-- | @O(1)@ Minimum element.
+minimum :: Prim a
+  => AscList a -> a
+{-# inlineable minimum #-}
+{-# specialize minimum :: AscList Int -> Int #-}
+{-# specialize minimum :: AscList Int64 -> Int64 #-}
+{-# specialize minimum :: AscList Double -> Double #-}
+minimum (AscList arr) = Arr.index arr 0
+
+-- | @O(1)@ Maximum element.
+maximum :: Prim a
+  => AscList a -> a
+{-# inlineable maximum #-}
+{-# specialize maximum :: AscList Int -> Int #-}
+{-# specialize maximum :: AscList Int64 -> Int64 #-}
+{-# specialize maximum :: AscList Double -> Double #-}
+maximum (AscList arr) = Arr.index arr (Arr.size arr - 1)
 
 quartiles :: Prim a
   => AscList a -> Quartiles a

--- a/src/Statistics/Array/Types.hs
+++ b/src/Statistics/Array/Types.hs
@@ -10,7 +10,9 @@ module Statistics.Array.Types
   , Quartiles(..)
   ) where
 
+import Data.Int
 import Data.Primitive.Contiguous (Contiguous, Element)
+import Data.Primitive (Prim,PrimArray)
 
 import qualified Data.Primitive.Contiguous as Arr
 import qualified Data.Primitive.Sort as Arr
@@ -20,33 +22,39 @@ import qualified Data.Primitive.Sort as Arr
 --
 -- I am keeping the implementation under-the-hood, as there are certainly better
 -- ways to represent this data than an actual linked list.
-newtype AscList arr e = AscList (arr e)
+newtype AscList e = AscList (PrimArray e)
 
-fromArray :: (Contiguous arr, Element arr e, Ord e) => arr e -> Maybe (AscList arr e)
+fromArray :: (Prim e, Ord e)
+  => PrimArray e -> Maybe (AscList e)
+{-# inlineable fromArray #-}
+{-# specialize fromArray :: PrimArray Int -> Maybe (AscList Int) #-}
+{-# specialize fromArray :: PrimArray Int64 -> Maybe (AscList Int64) #-}
+{-# specialize fromArray :: PrimArray Double -> Maybe (AscList Double) #-}
 fromArray xs
   | Arr.null xs = Nothing
-  | otherwise = Just . AscList . Arr.sort $ xs
+  | otherwise = Just $! AscList (Arr.sort xs)
 
 -- | Unsafe because if the input array is empty or not sorted ascending, functions
 -- operating on the resulting 'AscList' may (will) produce incorrect results.
-unsafeFromAscendingArray :: (Contiguous arr, Element arr e) => arr e -> AscList arr e
+unsafeFromAscendingArray :: Prim e
+  => PrimArray e -> AscList e
+{-# inline unsafeFromAscendingArray #-}
 unsafeFromAscendingArray = AscList
 
-fromList :: forall arr e.
-  (Contiguous arr, Element arr e, Ord e) => [e] -> Maybe (AscList arr e)
+fromList :: forall e. (Prim e, Ord e) => [e] -> Maybe (AscList e)
 fromList xs
   | null xs = Nothing
   | otherwise = Just . AscList . Arr.sort . Arr.fromList $ xs -- WARNING inefficent, but hey... you're using lists, scrub
 
 -- | Unsafe because if the input list is empty or not sorted ascending, functions
 -- operating on the resulting 'AscList' may (will) produce incorrect results.
-unsafeFromAscendingList :: forall arr e.
-  (Contiguous arr, Element arr e) => [e] -> AscList arr e
+unsafeFromAscendingList :: forall e. Prim e => [e] -> AscList e
+{-# inline unsafeFromAscendingList #-}
 unsafeFromAscendingList = AscList . Arr.fromList
 
 data Quartiles a = Quartiles
-  { q1 :: a
-  , q2 :: a
-  , q3 :: a
+  { q1 :: !a
+  , q2 :: !a
+  , q3 :: !a
   }
   deriving (Show, Eq)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Data.List (sort)
 import Data.Maybe (isJust)
-import Data.Primitive.Contiguous (SmallArray)
+import Data.Primitive.Contiguous (PrimArray)
 import Statistics.Array.Types (AscList,Quartiles(..))
 import Test.Tasty (defaultMain,testGroup)
 import Test.Tasty.HUnit (testCase,(@=?))
@@ -18,53 +18,53 @@ main :: IO ()
 main = defaultMain $ testGroup "stats"
   [ testGroup "quartiles"
     [ testCase "empty" $
-      let arr = Arr.empty :: SmallArray Int
+      let arr = Arr.empty :: PrimArray Int
        in (Stats.quartiles <$> Asc.fromArray arr) @=? Nothing
     , testProperty "singleton" $ \x ->
-      let arr = Arr.singleton x :: SmallArray Int
+      let arr = Arr.singleton x :: PrimArray Int
        in (Stats.quartiles <$> Asc.fromArray arr) === Just (Quartiles x x x)
     , testProperty "doubleton" $ \x0 y0 ->
       let (x, y) = if x0 <= y0 then (x0,y0) else (y0,x0)
-          arr = Arr.doubleton x y :: SmallArray Int
+          arr = Arr.doubleton x y :: PrimArray Int
        in (Stats.quartiles <$> Asc.fromArray arr) === Just (Quartiles x y y)
     , testProperty "tripleton" $ \x0 y0 z0 ->
       let (x1, y1) = if x0 <= y0 then (x0,y0) else (y0,x0)
           (x,y,z) = if z0 < x1 then (z0,x1,y1) else
                     if z0 < y1 then (x1,z0,y1) else
                       (x1,y1,z0)
-          arr = Arr.tripleton x y z :: SmallArray Int
+          arr = Arr.tripleton x y z :: PrimArray Int
        in (Stats.quartiles <$> Asc.fromArray arr) === Just (Quartiles x y z)
     , testCase "bigun" $
-      let arr = Arr.fromList nineDatums :: SmallArray Int
+      let arr = Arr.fromList nineDatums :: PrimArray Int
        in (Stats.quartiles <$> Asc.fromArray arr) @=? Just (Quartiles 3 4 8)
     ]
   , testProperty "median is second quartile" $ \xs ->
-      let asc = Asc.fromList xs :: Maybe (AscList SmallArray Int)
+      let asc = Asc.fromList xs :: Maybe (AscList Int)
        in isJust asc ==>
           (Stats.median <$> asc) === (q2 . Stats.quartiles <$> asc)
   , testGroup "bowley skew" $
     [ testCase "smoke" $
-      let arr = Arr.fromList nineDatums :: SmallArray Int
+      let arr = Arr.fromList nineDatums :: PrimArray Int
           qs = Stats.quartiles <$> Asc.fromArray arr
        in (Stats.bowleySkew <$> qs) @=? Just 0.6
     , testProperty "outlier" $ \x ->
-      let arr = Arr.fromList (x:eightDatums) :: SmallArray Int
+      let arr = Arr.fromList (x:eightDatums) :: PrimArray Int
           qs = Stats.quartiles <$> Asc.fromArray arr
        in x > 9 ==>
           (Stats.bowleySkew <$> qs) === Just 0.6
     ]
   , testGroup "median of absolute deviations" $
     [ testCase "smoke" $
-      let arr = Arr.fromList nineDatums :: SmallArray Int
+      let arr = Arr.fromList nineDatums :: PrimArray Int
        in (Stats.mad <$> Asc.fromArray arr) @=? Just 2
     ]
   , testGroup "list derivative" $
     [ testProperty "like naive" $ \unsortedXs ->
       let xs = sort unsortedXs
           lst' = zipWith (-) (tail xs) xs
-          asc = Asc.unsafeFromAscendingList xs :: AscList SmallArray Int
+          asc = Asc.unsafeFromAscendingList xs :: AscList Int
        in (not . null) xs ==>
-          (Stats.listDerivative asc) === (Arr.fromList lst' :: SmallArray Int)
+          (Stats.listDerivative asc) === (Arr.fromList lst' :: PrimArray Int)
     ]
   ]
 


### PR DESCRIPTION
Bump primitive-sort to newer version that only works with PrimArray. This makes GHC's specialization work correctly. Adjust API accordingly, and verify by inspection Core and benchmarking.